### PR TITLE
[Feature] Adding color option to Slider, with some examples

### DIFF
--- a/cpp_examples/example.cpp
+++ b/cpp_examples/example.cpp
@@ -18,7 +18,7 @@ int main() {
             Password,
             y
         }
-        Slider {
+        RedLight Slider {
             "Test: ",
             x,
             0,

--- a/examples/Slider.qf
+++ b/examples/Slider.qf
@@ -1,35 +1,23 @@
 Vertical{
     int x = 5
-    Slider{
+    Blue Slider{
         "Slider 1: ",
         x,
         0,
         100,
         1
     }
-    Horizontal{
-        int y = 40
-        Slider{
-            "Slider 2: ",
-            y,
-            0,
-            100,
-            2
-        }
-        int z = 90
-        Slider{
-            "Slider 3: ",
-            z,
-            0,
-            100,
-            5
-        }
+    int y = 40
+    YellowLight Slider{
+        "Slider 2: ",
+        y,
+        0,
+        100,
+        2
     }
-    Horizontal{
-        Button{
-            "Exit",
-            "Exit",
-            Animated
-        }
+    White Button{
+        "Exit",
+        "Exit",
+        Animated
     }
 }

--- a/include/quick-ftxui.hpp
+++ b/include/quick-ftxui.hpp
@@ -126,6 +126,7 @@ struct input {
 };
 
 struct slider {
+  colours color = colours::NoColor;
   std::string label;
   std::string value;
   int min;
@@ -219,6 +220,7 @@ BOOST_FUSION_ADAPT_STRUCT(quick_ftxui_ast::input,
 )
 
 BOOST_FUSION_ADAPT_STRUCT(quick_ftxui_ast::slider,
+                          (quick_ftxui_ast::colours, color)
                           (std::string, label)
                           (std::string, value)
                           (int, min)
@@ -434,9 +436,13 @@ struct node_printer : boost::static_visitor<> {
 
     if (auto It = quick_ftxui_ast::numbers.find(std::string(text.value));
         It != quick_ftxui_ast::numbers.end()) {
-      data->components.push_back(ftxui::Slider(text.label, (int *)(&It->second),
-                                               text.min, text.max,
-                                               text.increment));
+      ftxui::SliderOption<int> slider_opt;
+      slider_opt.value = (int *)(&It->second);
+      slider_opt.min = text.min, slider_opt.max = text.max, slider_opt.increment = text.increment;
+      slider_opt.color_active = resolveColour(text.color), slider_opt.color_inactive = ftxui::Color::GrayDark;
+      auto sldr = ftxui::Slider<int>(slider_opt);
+      auto with_label = ftxui::Renderer(sldr, [sldr, &text]{ return ftxui::hbox({ftxui::text(text.label), sldr->Render()}); });
+      data->components.push_back(with_label);
     } else {
       throw std::runtime_error("Variable " + text.value + " not found");
     }
@@ -670,7 +676,7 @@ struct parser
     input_comp %= qi::lit("Input") >> '{' >> quoted_string >>
                   -(',' >> inputopt_kw) >> ',' >> identifier >> '}';
 
-    slider_comp %= qi::lit("Slider") >> '{' >> quoted_string >> ',' >>
+    slider_comp %= -(color_kw) >> qi::lit("Slider") >> '{' >> quoted_string >> ',' >>
                    identifier >> ',' >> qi::int_ >> ',' >> qi::int_ >> ',' >>
                    qi::int_ >> '}';
 

--- a/include/quick-ftxui.hpp
+++ b/include/quick-ftxui.hpp
@@ -438,10 +438,14 @@ struct node_printer : boost::static_visitor<> {
         It != quick_ftxui_ast::numbers.end()) {
       ftxui::SliderOption<int> slider_opt;
       slider_opt.value = (int *)(&It->second);
-      slider_opt.min = text.min, slider_opt.max = text.max, slider_opt.increment = text.increment;
-      slider_opt.color_active = resolveColour(text.color), slider_opt.color_inactive = ftxui::Color::GrayDark;
+      slider_opt.min = text.min, slider_opt.max = text.max,
+      slider_opt.increment = text.increment;
+      slider_opt.color_active = resolveColour(text.color),
+      slider_opt.color_inactive = ftxui::Color::GrayDark;
       auto sldr = ftxui::Slider<int>(slider_opt);
-      auto with_label = ftxui::Renderer(sldr, [sldr, &text]{ return ftxui::hbox({ftxui::text(text.label), sldr->Render()}); });
+      auto with_label = ftxui::Renderer(sldr, [sldr, &text] {
+        return ftxui::hbox({ftxui::text(text.label), sldr->Render()});
+      });
       data->components.push_back(with_label);
     } else {
       throw std::runtime_error("Variable " + text.value + " not found");
@@ -676,9 +680,9 @@ struct parser
     input_comp %= qi::lit("Input") >> '{' >> quoted_string >>
                   -(',' >> inputopt_kw) >> ',' >> identifier >> '}';
 
-    slider_comp %= -(color_kw) >> qi::lit("Slider") >> '{' >> quoted_string >> ',' >>
-                   identifier >> ',' >> qi::int_ >> ',' >> qi::int_ >> ',' >>
-                   qi::int_ >> '}';
+    slider_comp %= -(color_kw) >> qi::lit("Slider") >> '{' >> quoted_string >>
+                   ',' >> identifier >> ',' >> qi::int_ >> ',' >> qi::int_ >>
+                   ',' >> qi::int_ >> '}';
 
     menu_comp %= qi::lit("Menu") >> '{' >> '[' >> +(quoted_string >> ',') >>
                  ']' >> -(',' >> menuopt_kw) >> ',' >> identifier >> '}';


### PR DESCRIPTION
Coloring option now supported for Slider. The grammar is:
```
YellowLight Slider{
        "Slider 2: ",
        y,
        0,
        100,
        2
    }
```
References: #2 
[Output](https://user-images.githubusercontent.com/103848930/266580209-938ae80a-fd95-4de9-ab55-46bbf3ea6caa.mp4)