### PR TITLE
[Feature] Adding color options for Input and Menu, along with their examples

### DIFF
--- a/examples/input.qf
+++ b/examples/input.qf
@@ -2,17 +2,17 @@ Vertical {
     str f = "John"
     str l = "Doe"
     str p
-    Input {
+    GreenLight Input {
         "First Name....",
-        Default,
+        None,
         f
     }
-    Input {
+    BlueLight Input {
         "Last Name....",
-        Default,
+        None,
         l
     }
-    Input {
+    Red Input {
         "Password....",
         Password,
         p

--- a/examples/menu_toggle_dropdown.qf
+++ b/examples/menu_toggle_dropdown.qf
@@ -1,10 +1,16 @@
 Vertical
 {
     int x
-    Menu{
+    Blue Menu{
         [ "Physics", "Maths", "Chemistry", "Biology",],
         HorizontalAnimated,
         x
+    }
+    int a
+    Green Menu {
+        [ "Physics", "Maths", "Chemistry", "Biology",],
+        Vertical,
+        a
     }
     int y
     int z


### PR DESCRIPTION
The syntax for Input is:
```
GreenLight Input {
    "First Name....",
    None,
    f
}
```
And syntax for Menu is:
```
Blue Menu{
    [ "Physics", "Maths", "Chemistry", "Biology",],
    HorizontalAnimated,
    x
}
```
References: #2 
Output: https://github.com/vrnimje/quick-ftxui/issues/2#issuecomment-1712477278