### PR TITLE
[Feature] Adding color options for Toggle and Dropdown, with examples for the same

### DIFF
--- a/examples/menu_toggle_dropdown.qf
+++ b/examples/menu_toggle_dropdown.qf
@@ -1,7 +1,7 @@
 Vertical
 {
     int x
-    Blue Menu{
+    Red Menu{
         [ "Physics", "Maths", "Chemistry", "Biology",],
         HorizontalAnimated,
         x
@@ -14,11 +14,11 @@ Vertical
     }
     int y
     int z
-    Toggle {
+    Cyan Toggle {
         [ "On", "Off", ],
         y
     }
-    Dropdown {
+    BlueLight Dropdown {
         [ "Zain", "Mahesh", "Alqama", "Vaidic", "Mundane", "Advait", ],
         z
     }


### PR DESCRIPTION
Syntax for Toggle is:
```
Cyan Toggle {
    [ "On", "Off", ],
    y
}
```

Syntax for Dropdown is:
```
BlueLight Dropdown {
    [ "Zain", "Mahesh", "Alqama", "Vaidic", "Mundane", "Advait", ],
    z
}
```

Output: https://github.com/vrnimje/quick-ftxui/issues/2#issuecomment-1712492296
References: #2 