### PR TITLE
[Feature] Adding paragraph, and made minor change to text's grammar

### DIFF
--- a/examples/Button.qf
+++ b/examples/Button.qf
@@ -19,7 +19,7 @@ Vertical{
         }
     }
     Heavy separator
-    text("This button exits the TUI")
+    Text("This button exits the TUI")
     Button {
         "Exit",
         "Exit"

--- a/examples/paragraph.qf
+++ b/examples/paragraph.qf
@@ -1,0 +1,13 @@
+Vertical {
+    MagentaLight Paragraph("In probability theory and statistics, Bayes' theorem (alternatively Bayes' law or Bayes' rule) describes the probability of an event, based on prior knowledge of conditions that might be related to the event. For example, if cancer is related to age, then, using Bayes' theorem, a person's age can be used to more accurately assess the probability that they have cancer, compared to the assessment of the probability of cancer made without knowledge of the person's age. One of the many applications of Bayes' theorem is Bayesian inference, a particular approach to statistical inference. When applied, the probabilities involved in Bayes' theorem may have different probability interpretations. With the Bayesian probability interpretation the theorem expresses how a subjective degree of belief should rationally change to account for availability of related evidence. Bayesian inference is fundamental to Bayesian statistics.")
+    Heavy separator
+    Horizontal {
+        RedLight Paragraph("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+        Double separator
+        Paragraph("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+    }
+    Button {
+        "X",
+        "Exit"
+    }
+}

--- a/examples/separator.qf
+++ b/examples/separator.qf
@@ -1,17 +1,17 @@
 Vertical{
-    text("Normal")
+    Text("Normal")
     Normal separator
-    text("Light")
+    Text("Light")
     Light separator
-    text("Heavy")
+    Text("Heavy")
     Heavy separator
     Horizontal {
-        text("Double")
+        Text("Double")
         Double separator
-        text("lorem ipsum")    
+        Text("lorem ipsum")    
     }
     separator
-    text("Dashed")
+    Text("Dashed")
     Dashed separator
     Button {
         "Exit",

--- a/examples/text.qf
+++ b/examples/text.qf
@@ -1,5 +1,5 @@
 Vertical {
-    Blue text("The given button opens chrome in Linux")
+    Blue Text("The given button opens chrome in Linux")
     str a
     Red Button {
         "chrome",
@@ -7,7 +7,7 @@ Vertical {
         Animated,
         a
     }
-    Green text("This text is Green")
+    Green Text("This text is Green")
     Button {
         "Exit",
         "Exit"


### PR DESCRIPTION
Syntax for Paragraph is:
```
RedLight Paragraph("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
```

Output:

https://github.com/vrnimje/quick-ftxui/assets/103848930/25b32b61-3142-4b88-99f4-6ad677809ad4


Difference between `Paragraph` and `Text` is that Text doesn't adapt to the terminal window size, meaning its contents will overflow. Paragraph does, as demonstrated above

Also, syntax for `Text` is now changed, from `text`, to maintain consistency with other dom/components

References #5 