### PR TITLE
[Feature] Adding Text styles

### DIFF
--- a/examples/text.qf
+++ b/examples/text.qf
@@ -1,5 +1,5 @@
 Vertical {
-    Blue Text("The given button opens chrome in Linux")
+    bold BlueLight Text("The given button opens chrome in Linux")
     str a
     Red Button {
         "chrome",
@@ -7,7 +7,7 @@ Vertical {
         Animated,
         a
     }
-    Green Text("This text is Green")
+    strikethrough Green Text("This text is Green")
     Button {
         "Exit",
         "Exit"

--- a/examples/text_styles.qf
+++ b/examples/text_styles.qf
@@ -1,0 +1,14 @@
+Vertical {
+    Text("This is normal")
+    bold Yellow Text("This is bold, yellow text")
+    dim Text("This is dim")
+    underlined Text("Underlined text")
+    underlinedDouble Magenta Text("Double underlines!!")
+    blink Text("This is blinking")
+    inverted Red Text("This has an inverted look")
+    strikethrough Text("This is strikethrough")
+    Red Button {
+        "X",
+        "Exit"
+    }
+}


### PR DESCRIPTION
The following text styles are supported
* bold
* dim
* underlined
* underlinedDouble
* inverted
* blink
* strikethrough

Updated syntax is:
```
bold Green Text("Hey, this is bold and green")
```

Output: https://github.com/vrnimje/quick-ftxui/issues/5#issuecomment-1721038594

References: #5 