### PR TITLE
[Feature] Added block-level border decorator, along with styles & examples

### DIFF
--- a/examples/Button.qf
+++ b/examples/Button.qf
@@ -1,9 +1,9 @@
-Vertical{
+LightBorder Vertical{
     int x = 5
     str y = "Test"
     str z = "init"
     str a
-    Horizontal {
+    DashedBorder Horizontal {
         Red Button {
             "ls -l",
             System("ls -l"),

--- a/examples/border.qf
+++ b/examples/border.qf
@@ -1,0 +1,25 @@
+Vertical {
+    Border Vertical {
+        Text("This is normal border")
+    }
+
+    LightBorder Vertical {
+        Text("This is light border")
+    }
+
+    HeavyBorder Vertical {
+        Text("This is heavy border")
+    }
+
+    DashedBorder Horizontal {
+        Text("This is dashed border")
+    }
+
+    RoundedBorder Vertical {
+        Text("This is rounded border")
+    }
+
+    DoubleBorder Vertical {
+        Text("This is double border")
+    }
+}


### PR DESCRIPTION
Border styles supported are:
* Light
* Heavy
* Dashed
* Double
* Rounded

Syntax:
```
LightBorder Vertical {
    Text("This is light border")
}
```

Output:
![image](https://github.com/vrnimje/quick-ftxui/assets/103848930/b9f5c0d5-e882-49e6-88e2-5bd06ee317aa)

References: #5 