### PR TITLE
[Feature] Added hyperlink as a text style

### DIFF
--- a/examples/text.qf
+++ b/examples/text.qf
@@ -8,6 +8,9 @@ Vertical {
         a
     }
     strikethrough Green Text("This text is Green")
+    Horizontal {
+        hyperlink Blue Text("Google", "https://www.google.com/")
+    }
     Button {
         "Exit",
         "Exit"


### PR DESCRIPTION
Syntax:
```
hyperlink Blue Text("Google", "https://www.google.com/")
```

Output: 

https://github.com/vrnimje/quick-ftxui/assets/103848930/69fcb45a-a681-4e8f-89db-47f5f0aa3452

References: #5 