### PR TITLE
[CI] Adding workaround for failing Windows build

### DIFF
--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -20,14 +20,16 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set Git to use the Windows Certificate Store
-      run: git config --global http.sslBackend schannel
+    - name: Remove Strawberry Perl from PATH
+      run: |
+        $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", "" 
+        "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Configure CMake
       run: cmake -S . -B build "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DQUICK_FTXUI_FETCH_BOOST=ON

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -2,7 +2,7 @@ name: Windows Build Boost Fetch
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix_windows_ci ]
     paths:
       - ".github/workflows/windows_build_no_boost.yml"
       - "include/**"

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-19
+    runs-on: windows-2019
     env:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
     steps:

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -25,6 +25,17 @@ jobs:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Install OpenSSL
+      run: choco install openssl.light
+
+    - name: Get GitHub SSL certificate
+      run: |
+        echo | openssl s_client -servername github.com -connect github.com:443 2>/dev/null | openssl x509 > github.crt
+
+    - name: Add GitHub SSL certificate to trusted store
+      run: |
+        certutil -addstore -f "Root" github.crt
 
     - name: Configure CMake
       run: cmake -S . -B build "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DQUICK_FTXUI_FETCH_BOOST=ON

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -2,7 +2,7 @@ name: Windows Build Boost Fetch
 
 on:
   push:
-    branches: [ master, fix_windows_ci ]
+    branches: [ master ]
     paths:
       - ".github/workflows/windows_build_no_boost.yml"
       - "include/**"
@@ -25,17 +25,9 @@ jobs:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
     steps:
     - uses: actions/checkout@v2
-    
-    - name: Install OpenSSL
-      run: choco install openssl.light
 
-    - name: Get GitHub SSL certificate
-      run: |
-        echo "" | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.cer
-
-    - name: Add GitHub SSL certificate to trusted store
-      run: |
-        certutil -addstore -f "Root" github.cer
+    - name: Set Git to use the Windows Certificate Store
+      run: git config --global http.sslBackend schannel
 
     - name: Configure CMake
       run: cmake -S . -B build "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DQUICK_FTXUI_FETCH_BOOST=ON

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -31,11 +31,11 @@ jobs:
 
     - name: Get GitHub SSL certificate
       run: |
-        echo "" | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.crt
+        echo "" | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.cer
 
     - name: Add GitHub SSL certificate to trusted store
       run: |
-        certutil -addstore -f "Root" github.crt
+        certutil -addstore -f "Root" github.cer
 
     - name: Configure CMake
       run: cmake -S . -B build "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DQUICK_FTXUI_FETCH_BOOST=ON

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -20,10 +20,9 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-19
     env:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
-      SSL_CERT_DIR: HKEY_LOCAL_MACHINE\Software\Microsoft\SystemCertificates
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Get GitHub SSL certificate
       run: |
-        echo | openssl s_client -servername github.com -connect github.com:443 2>/dev/null | openssl x509 > github.crt
+        echo | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.crt
 
     - name: Add GitHub SSL certificate to trusted store
       run: |

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Get GitHub SSL certificate
       run: |
-        echo | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.crt
+        echo "" | openssl s_client -servername github.com -connect github.com:443 2>NUL | openssl x509 > github.crt
 
     - name: Add GitHub SSL certificate to trusted store
       run: |

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: windows-2022
     env:
       CMAKE_PREFIX_PATH: ${{ github.workspace }}\.local
+      SSL_CERT_DIR: HKEY_LOCAL_MACHINE\Software\Microsoft\SystemCertificates
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -2,7 +2,7 @@ name: Windows Build Boost Fetch
 
 on:
   push:
-    branches: [ master, fix_windows_ci ]
+    branches: [ master ]
     paths:
       - ".github/workflows/windows_build_no_boost.yml"
       - "include/**"


### PR DESCRIPTION
The failing action was caused due to recent update of runner-image in Windows
A tracker is currently active for the same: https://github.com/actions/runner-images/issues/8598
This PR is meant only as a **temporary** fix

References: #33 