### PR TITLE
[CI] Fixed Linux Build failing, and reverted Windows Build workaround

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -2,7 +2,7 @@ name: Linux Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, win_rev_linux_fix ]
     paths:
       - ".github/workflows/linux_build.yml"
       - "include/**"
@@ -27,12 +27,12 @@ jobs:
       matrix:
         cxx:
           - g++-10
-          - clang++-12
+          - clang++-14
         include:
           - cxx: g++-10
             compiler: g++-10
-          - cxx: clang++-12
-            compiler: clang++-12
+          - cxx: clang++-14
+            compiler: clang++-14
     env:
       CXX: ${{matrix.cxx}}
       CMAKE_PREFIX_PATH: ${{github.workspace}}/.local

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -27,12 +27,12 @@ jobs:
       matrix:
         cxx:
           - g++-10
-          - clang++-14
+          - clang++-12
         include:
           - cxx: g++-10
             compiler: g++-10
-          - cxx: clang++-14
-            compiler: clang++-14
+          - cxx: clang++-12
+            compiler: clang++-12
     env:
       CXX: ${{matrix.cxx}}
       CMAKE_PREFIX_PATH: ${{github.workspace}}/.local

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -2,7 +2,7 @@ name: Linux Build
 
 on:
   push:
-    branches: [ master, win_rev_linux_fix ]
+    branches: [ master ]
     paths:
       - ".github/workflows/linux_build.yml"
       - "include/**"

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -26,11 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Remove Strawberry Perl from PATH
-      run: |
-        $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", "" 
-        "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
-
     - name: Configure CMake
       run: cmake -S . -B build "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DQUICK_FTXUI_FETCH_BOOST=ON
         

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -2,7 +2,7 @@ name: Windows Build Boost Fetch
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, win_rev_linux_fix ]
     paths:
       - ".github/workflows/windows_build_no_boost.yml"
       - "include/**"

--- a/.github/workflows/windows_build_no_boost.yml
+++ b/.github/workflows/windows_build_no_boost.yml
@@ -2,12 +2,12 @@ name: Windows Build Boost Fetch
 
 on:
   push:
-    branches: [ master, win_rev_linux_fix ]
+    branches: [ master ]
     paths:
       - ".github/workflows/windows_build_no_boost.yml"
       - "include/**"
       - "src/**"
-      - "tests/**"
+      - "tests/**", win_rev_linux_fix
       - "CMakeLists.txt"
   pull_request:
     branches: [ master ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(QUICK_FTXUI_TESTS)
     FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.0.1 # or a later release
+        GIT_TAG v3.4.0 # or a later release
     )
 
     FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
* Updated Catch2 to v3.4.0

The runner-image for Windows has now been fixed

Closes: #33 